### PR TITLE
Implement two-phase testing with HiddifyCLI and Namira-core

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,6 +20,21 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+
+      - name: Download and prepare Namira-core
+        run: |
+          NAMIRA_LATEST_RELEASE_URL=$(curl -s "https://api.github.com/repos/NamiraNet/namira-core/releases/latest" | grep "browser_download_url.*linux-amd64" | cut -d '"' -f 4)
+          if [ -z "$NAMIRA_LATEST_RELEASE_URL" ]; then
+            echo "Error: Could not find Namira-core linux-amd64 release URL."
+            # Fallback to a known older version if API fails or URL not found, though this is not ideal
+            echo "Attempting to download a fallback version v0.2.7."
+            NAMIRA_LATEST_RELEASE_URL="https://github.com/NamiraNet/namira-core/releases/download/v0.2.7/namira-core-linux-amd64"
+            # exit 1 # Option to fail the job if latest can't be found
+          fi
+          echo "Downloading Namira-core from $NAMIRA_LATEST_RELEASE_URL"
+          curl -L -o namira-core-linux-amd64 $NAMIRA_LATEST_RELEASE_URL
+          chmod +x namira-core-linux-amd64
+          ./namira-core-linux-amd64 --version # Verify download
           
       - name: Execute PHP script
         run: |


### PR DESCRIPTION
Integrates a two-phase testing process into the configuration pipeline:

1.  **Phase 1:** Existing HiddifyCli test filters initial configs.
2.  **Phase 2:** Namira-core provides advanced testing for VMess, VLESS, Trojan, and Shadowsocks configs that passed Phase 1. TUIC and Hysteria2 configs bypass Phase 2 if they passed Phase 1.

- Modifies `config-test.php` to orchestrate the two phases, ensuring `config.txt` receives the final, validated list.
- Updates the GitHub Actions workflow in `php.yml` to download and prepare the Namira-core binary before tests are run.
- Ensures the output structure in the `/subscriptions` directory and user-facing URLs remain unchanged, improving only the quality of configs.