### PR TITLE
Fix: Correct Namira-core download and extraction in GHA workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,18 +23,31 @@ jobs:
 
       - name: Download and prepare Namira-core
         run: |
-          NAMIRA_LATEST_RELEASE_URL=$(curl -s "https://api.github.com/repos/NamiraNet/namira-core/releases/latest" | grep "browser_download_url.*linux-amd64" | cut -d '"' -f 4)
-          if [ -z "$NAMIRA_LATEST_RELEASE_URL" ]; then
-            echo "Error: Could not find Namira-core linux-amd64 release URL."
-            # Fallback to a known older version if API fails or URL not found, though this is not ideal
-            echo "Attempting to download a fallback version v0.2.7."
-            NAMIRA_LATEST_RELEASE_URL="https://github.com/NamiraNet/namira-core/releases/download/v0.2.7/namira-core-linux-amd64"
-            # exit 1 # Option to fail the job if latest can't be found
+          # Find the URL for the correct asset (the .tar.gz file) from the latest release
+          ASSET_URL=$(curl -s "https://api.github.com/repos/NamiraNet/namira-core/releases/latest" | grep "browser_download_url.*linux_amd64.tar.gz" | cut -d '"' -f 4)
+
+          if [ -z "$ASSET_URL" ]; then
+            echo "Error: Could not automatically find the latest Namira-core release URL."
+            echo "Attempting to download fallback version v1.1.0."
+            # Correct fallback URL to the .tar.gz file
+            ASSET_URL="https://github.com/NamiraNet/namira-core/releases/download/v1.1.0/namira-core_1.1.0_linux_amd64.tar.gz"
           fi
-          echo "Downloading Namira-core from $NAMIRA_LATEST_RELEASE_URL"
-          curl -L -o namira-core-linux-amd64 $NAMIRA_LATEST_RELEASE_URL
+
+          echo "Downloading Namira-core archive from $ASSET_URL"
+          # Download the tar.gz archive
+          curl -L -o namira-core.tar.gz "$ASSET_URL"
+
+          # Extract the binary from the archive
+          echo "Extracting binary..."
+          tar -xzf namira-core.tar.gz namira-core
+
+          # Rename the extracted binary to match the name expected by the PHP script
+          mv namira-core namira-core-linux-amd64
+
           chmod +x namira-core-linux-amd64
-          ./namira-core-linux-amd64 --version # Verify download
+
+          echo "Verifying Namira-core version:"
+          ./namira-core-linux-amd64 --version
           
       - name: Execute PHP script
         run: |


### PR DESCRIPTION
Updates the GitHub Actions workflow to correctly download the namira-core .tar.gz archive, extract the binary, and rename it to `namira-core-linux-amd64` as expected by the PHP testing script.

This resolves an issue where the workflow was attempting to download a non-binary file, leading to execution errors.